### PR TITLE
Kasai pull req

### DIFF
--- a/DRONE.m
+++ b/DRONE.m
@@ -22,13 +22,19 @@ classdef DRONE < ABSTRACT_SYSTEM
             % logger : LOGGER class instance
             % param.realtime (optional) : t-or-f : logger.data('t')を使うか
             % param.target = 1:4 描画するドローンのインデックス
+            % param.gif = 0 or 1 gif画像として出力するか選択（1で出力＆Dataフォルダに保存）
+            % param.Motive_ref = 0 or 1 動画内の目標軌道をMotiveみたいに徐々に消える形にするか選択（1でMotiveモード）
+            % param.fig_num = 1 gif出力するfigure番号の選択（デフォルトはfigure１）
             arguments
                 obj
                 logger
                 param.target = 1;
+                param.gif = 0;
+                param.Motive_ref = 0;
+                param.fig_num = 1;
             end
             p = obj.parameter;
-            DRAW_DRONE_MOTION(logger,"frame_size",[p.Lx,p.Ly],"rotor_r",p.rotor_r,"animation",true,"target",param.target);
+            DRAW_DRONE_MOTION(logger,"frame_size",[p.Lx,p.Ly],"rotor_r",p.rotor_r,"animation",true,"target",param.target,"gif",param.gif,"Motive_ref",param.Motive_ref,"fig_num",param.fig_num);
         end
     end
 end

--- a/plot/DRAW_DRONE_MOTION.m
+++ b/plot/DRAW_DRONE_MOTION.m
@@ -25,6 +25,9 @@ classdef DRAW_DRONE_MOTION
                 param.plot_ref = true;
                 param.animation = false;
                 param.target = 1;
+                param.gif = 0;
+                param.Motive_ref = 0;
+                param.fig_num = 1;
             end
             data = logger.data(param.target,"p","e");
             tM = max(data);
@@ -37,7 +40,7 @@ classdef DRAW_DRONE_MOTION
             xlabel(ax,"x [m]");
             ylabel(ax,"y [m]");
             zlabel(ax,"z [m]");
-            obj.fig = ax;
+            obj.fig = figure(param.fig_num);
 
             view(3)
             grid on
@@ -82,7 +85,7 @@ classdef DRAW_DRONE_MOTION
             obj.frame = t;
             obj.thrust = tt;
             if param.animation
-                obj.animation(logger,"realtime",true,"target",param.target);
+                obj.animation(logger,"realtime",true,"target",param.target,"gif",param.gif,"Motive_ref",param.Motive_ref,"fig_num",param.fig_num);
             end
         end
 
@@ -133,6 +136,8 @@ classdef DRAW_DRONE_MOTION
                 param.realtime = false;
                 param.target = 1;
                 param.gif = 0;
+                param.Motive_ref = 0;
+                param.fig_num = 1;
             end
 
             %p = logger.data(param.target,"p","e");
@@ -148,7 +153,7 @@ classdef DRAW_DRONE_MOTION
             for n = 1:length(param.target)
                 switch size(q(:,:,n),2)
                     case 3
-                        Q1 = quaternion(q(:,:,n),'euler','ZYX','frame');
+                        Q1 = quaternion(q(:,:,n),'euler','XYZ','frame');
                     case 4
                         Q1 = quaternion(q(:,:,n));
                     case 9
@@ -170,10 +175,22 @@ classdef DRAW_DRONE_MOTION
 
             t = logger.data("t");
             tRealtime = tic;
-            for i = 1:length(t)-1
+            if param.Motive_ref
                 for n = 1:length(param.target)
-                    plot3(r(:,1,n),r(:,2,n),r(:,3,n),'k');
-                    obj.draw(obj.frame(param.target(n)),obj.thrust(param.target(n),:),p(i,:,n),Q(i,:,n),u(i,:,n));
+                    f(n) = animatedline('Color','r','MaximumNumPoints',15); % 目標軌道の描画点の制限
+                end
+            end
+            for i = 1:length(t)-1
+                if param.Motive_ref
+                    for n = 1:length(param.target)
+                        addpoints(f(n),r(i,1,n),r(i,2,n),r(i,3,n));
+                        obj.draw(obj.frame(param.target(n)),obj.thrust(param.target(n),:),p(i,:,n),Q(i,:,n),u(i,:,n));
+                    end
+                else
+                    for n = 1:length(param.target)
+                        plot3(r(:,1,n),r(:,2,n),r(:,3,n),'k');
+                        obj.draw(obj.frame(param.target(n)),obj.thrust(param.target(n),:),p(i,:,n),Q(i,:,n),u(i,:,n));
+                    end
                 end
                 if param.realtime
                     delta = toc(tRealtime);


### PR DESCRIPTION
## やったこと

* agent.animationの改良

## やらないこと

* なし

## できるようになること（ユーザ目線）

* gifファイルの出力選択（「"gif",1」ならgifファイルを生成＆Dataフォルダに保存（ファイル名は生成時刻）．デフォルトは出力しないように0）
* gif出力するfigure番号の選択（デフォルトはfigure(1)が選択されている．もし複数の動画を表示するようになったら「"fig_num",3」のようにするとfigure(3)の動画を出力・保存できる）
* 目標軌道を全軌道一括表示かMotiveみたいな徐々に消えてくタイプかで選択（「"Motive_ref",1」でMotiveのような軌道が少しずつ表示される型に切り替えられる．デフォルトは0なので元の書式通り一括表示）

## できなくなること（ユーザ目線）

* なし

## 動作確認

* 実際に一項目追加するたびにmainで「"gif",1」や「"Motive_ref",1」，「"fig_num",1」で動くことを確認したほか，指定しない場合にきちんとデフォルトの設定が生きているか確認．
例　指定項目が「"target",1:N」だけならgif出力しない，目標軌道も一括で表示される，など

## Concerns and areas to focus on
- fig_numに関しては現状動画を一つしか生成していない関係上，複数の動画ウィンドウから選ぶとこまで検証出来ていません．ブレークポイントを付けて見ていたのでmainで指定した数字が渡ることだけ確認しました．
- コミットリンク
- コミットリンク
