### PR TITLE
Kasai pull req

### DIFF
--- a/DRONE.m
+++ b/DRONE.m
@@ -25,6 +25,7 @@ classdef DRONE < ABSTRACT_SYSTEM
             % param.gif = 0 or 1 gif画像として出力するか選択（1で出力＆Dataフォルダに保存）
             % param.Motive_ref = 0 or 1 動画内の目標軌道をMotiveみたいに徐々に消える形にするか選択（1でMotiveモード）
             % param.fig_num = 1 gif出力するfigure番号の選択（デフォルトはfigure１）
+            % param.mp4 = 0 or 1 mp4形式として出力するか選択（1で出力＆Dataフォルダに保存）
             arguments
                 obj
                 logger
@@ -32,9 +33,10 @@ classdef DRONE < ABSTRACT_SYSTEM
                 param.gif = 0;
                 param.Motive_ref = 0;
                 param.fig_num = 1;
+                param.mp4 = 0;
             end
             p = obj.parameter;
-            DRAW_DRONE_MOTION(logger,"frame_size",[p.Lx,p.Ly],"rotor_r",p.rotor_r,"animation",true,"target",param.target,"gif",param.gif,"Motive_ref",param.Motive_ref,"fig_num",param.fig_num);
+            DRAW_DRONE_MOTION(logger,"frame_size",[p.Lx,p.Ly],"rotor_r",p.rotor_r,"animation",true,"target",param.target,"gif",param.gif,"Motive_ref",param.Motive_ref,"fig_num",param.fig_num,"mp4",param.mp4);
         end
     end
 end

--- a/plot/DRAW_DRONE_MOTION.m
+++ b/plot/DRAW_DRONE_MOTION.m
@@ -28,6 +28,7 @@ classdef DRAW_DRONE_MOTION
                 param.gif = 0;
                 param.Motive_ref = 0;
                 param.fig_num = 1;
+                param.mp4 = 0;
             end
             data = logger.data(param.target,"p","e");
             tM = max(data);
@@ -85,7 +86,7 @@ classdef DRAW_DRONE_MOTION
             obj.frame = t;
             obj.thrust = tt;
             if param.animation
-                obj.animation(logger,"realtime",true,"target",param.target,"gif",param.gif,"Motive_ref",param.Motive_ref,"fig_num",param.fig_num);
+                obj.animation(logger,"realtime",true,"target",param.target,"gif",param.gif,"Motive_ref",param.Motive_ref,"fig_num",param.fig_num,"mp4",param.mp4);
             end
         end
 
@@ -138,6 +139,7 @@ classdef DRAW_DRONE_MOTION
                 param.gif = 0;
                 param.Motive_ref = 0;
                 param.fig_num = 1;
+                param.mp4 = 0;
             end
 
             %p = logger.data(param.target,"p","e");
@@ -171,6 +173,17 @@ classdef DRAW_DRONE_MOTION
                 sizen = 256;
                 delaytime = 0;
                 filename = strrep(strrep(strcat('Data/Movie(',datestr(datetime('now')),').gif'),':','_'),' ','_');
+            end
+
+            if param.mp4
+                sizen = 256;
+                delaytime = 0;
+                filename = strrep(strrep(strcat('Data/Movie(',datestr(datetime('now')),').mp4'),':','_'),' ','_');
+                v = VideoWriter(filename,"MPEG-4");
+                if param.mp4
+                    open(v);
+                    writeAnimation(v);
+                end
             end
 
             t = logger.data("t");
@@ -210,6 +223,13 @@ classdef DRAW_DRONE_MOTION
                         imwrite(imind,cm,filename,'gif','WriteMode','append','DelayTime',delaytime);
                     end
                 end
+                if param.mp4
+                    framev = getframe(obj.fig);
+                    writeVideo(v,framev);
+                end
+            end
+            if param.mp4
+                close(v);
             end
         end
     end


### PR DESCRIPTION
## やったこと

*共通プログラムの動画出力の部分で、ファイル形式としてmp4を選択できるように修正

## やらないこと

* なし

## できるようになること（ユーザ目線）

* gifだけでなくmp4でも出力・保存が出来る（保存先はgifに合わせてDataフォルダに設定）

## できなくなること（ユーザ目線）

* なし

## 動作確認

* 実際に鳥の追跡シミュレーションので保存できるか確認。きちんとDataフォルダに保存されていた。

## Concerns and areas to focus on
- 自分のノートPCでは元々gifの方も遅いだけで動いてはいたので、先生ので問題なく動くか確認してほしいです。
- あとmainで選ぶ分には自分が使いたい項目だけなのでそこまで気になりませんが、機能を追加するたびにフラグ管理のとこが横に長くなっているのでこのままでいいのか行列形式みたいな保存方法にした方がいいのか悩んでいます。
- コミットリンク
- コミットリンク
